### PR TITLE
Update CI to 0.6, not nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
 
 julia:
   - 0.5
-  - nightly
+  - 0.6
 
 before_install:
   # linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,13 +2,12 @@ environment:
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
 
 branches:
   only:
     - master
-    - /release-.*/
 
 notifications:
   - provider: Email


### PR DESCRIPTION
@staticfloat Thanks for this - it was broken because I hadn't updated to the 0.6 target instead of nightlies, now fixed (also for travis). Please can you adjust.